### PR TITLE
Typo OnDidReceiveRemoveNotification -> OnDidReceiveRemoteNotification

### DIFF
--- a/src/components/Boilerplate/Components/AppleAppDelegate.tsx
+++ b/src/components/Boilerplate/Components/AppleAppDelegate.tsx
@@ -23,7 +23,7 @@ const AppleAppDelegate = () => {
   
       [Export("application:didReceiveRemoteNotification:fetchCompletionHandler:")]
       public void DidReceiveRemoteNotification(UIApplication application, NSDictionary userInfo, Action<UIBackgroundFetchResult> completionHandler)
-          => global::Shiny.Hosting.Host.Lifecycle.OnDidReceiveRemoveNotification(userInfo, completionHandler);	
+          => global::Shiny.Hosting.Host.Lifecycle.OnDidReceiveRemoteNotification(userInfo, completionHandler);	
   
   }`;
   return (<Syntax source={src} />);


### PR DESCRIPTION
In one of the code samples to setup push notifications on iOS there is a typo in the method which prevented me to copy and paste 😝 