### PR TITLE
docs: update RoomSharp link to roomsharp.dev

### DIFF
--- a/src/content/docs/templates/third-party.mdx
+++ b/src/content/docs/templates/third-party.mdx
@@ -41,7 +41,7 @@ The Shiny Templates include a curated set of 3rd party libraries that are pre-co
 | Library | Description |
 |---|---|
 | <a href="https://github.com/praeclarum/sqlite-net" target="_blank">SQLite.NET-pcl</a> | SQLite ORM by Frank Krueger |
-| <a href="https://roomsharp.safwan.pro/" target="_blank">RoomSharp</a> | Database access layer by Safwan Abdulghani |
+| <a href="https://roomsharp.dev/" target="_blank">RoomSharp</a> | Database access layer by Safwan Abdulghani |
 | <a href="https://github.com/mrdevrobot/Community-LiteDb-AOT" target="_blank">Community LiteDB AOT</a> | AOT-compatible embedded document database |
 
 ## Networking & Authentication


### PR DESCRIPTION
Updated the RoomSharp website link from the old safwan.pro subdomain to the new official roomsharp.dev domain.