### PR TITLE
Show homepage menu button on mobile as bottom-right FAB

### DIFF
--- a/src/components/HomepageNav.astro
+++ b/src/components/HomepageNav.astro
@@ -113,9 +113,18 @@ const topics = sidebarTopics.map(topic => ({
     transform: translateY(0);
   }
 
-  @media (max-width: 72rem) {
+  /* On mobile, anchor to bottom-right so it can't overlap the
+     starlight-announcement banner at the top of the page. */
+  @media (max-width: 50rem) {
     .homenav-toggle {
-      display: none;
+      top: auto;
+      left: auto;
+      right: 1rem;
+      bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+      padding: 0.65rem 1.1rem 0.65rem 1rem;
+      box-shadow:
+        0 2px 6px rgba(0, 0, 0, 0.12),
+        0 8px 24px rgba(154, 129, 234, 0.25);
     }
   }
 


### PR DESCRIPTION
Previously the menu was hidden below 72rem, leaving mobile visitors on
the splash homepage with no nav. Re-anchor it to the bottom-right at
mobile widths so the announcement banner at the top of the page stays
unobstructed.